### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,70 @@
 # friendbook
 الكود الخاص بمشروع كتاب الأصدقاء 
 
-## مزيد من التفاصيل مع الشرح و التطبيق هنا:
-
-[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/PrPqBi_lSUc/0.jpg)](https://www.youtube.com/watch?v=PrPqBi_lSUc)ا
 ## طريقة الاستخدام
 
-1. انسخ هذا المشروع clone على جهازك الشخصي فى أى مكان
-2. فى شاشة الأوامر terminal /  command line interface  افتح المجلد و قم بكتابة الأمر   `yarn`  لتثبيت المكتبات التي يحتاجها المشروع للتشغيل
-3. اكتب الأمر `yarn build:release` لبناء و استخراج ملف wasm من الكود استعداداً لرفعه. ستجد بعد تنفيذ هذا الأمر ملف `friendbook.wasm` تم انشاءه فى هذا المسار `build\release` 
-4. قم بكتابة الأمر `near dev-deploy .\build\release\friendbook.wasm` لرفع الملف السابق على البلوك تشين 
-5. من المفروض بعد تنفيذ الأمر السابق أن تجد رسالة تحتوى على الحساب الذي تم انشاؤه و وضع الكود عليه - مثل dev-XXXXXX-XXXXXXX 
-6. هذا مثال لناتج تنفيذ الأمر السابق
+1. انسخ هذا المشروع clone على جهازك الشخصي فى أى مكان.
+2. فى شاشة الأوامر terminal /  command line interface  افتح المجلد وقم بتثبيت المكتبات التي يحتاجها المشروع للتشغيل عن طريق الأمر: 
 
-`Transaction Id EtdLuXkhT5eex1ubT1pRKhETZNv8AoAMzadHiJMdGH9z
-To see the transaction in the transaction explorer, please open this url in your browser
-https://explorer.testnet.near.org/transactions/EtdLuXkhT5eex1ubT1pRKhETZNv8AoAMzadHiJMdGH9z
-Done deploying to dev-1643380555927-18139425398700
-` 
+ ```
+yarn
+```
+ 
+3. لبناء واستخراج ملف wasm من الكود استعداداً لرفعه، استخدم الأمر التالي:
 
-8. قم بكتابة هذا الأمر لاستدعاء الدالة `near call CONTRACT_ACCOUNT_NAME METHOD_NAME '{PARAMETERS_IF_ANY}' --accountId=EXAMPLE.testnet`  
-9. ستجد ناتج الرسالة ظهر على شاشة الأوامر بناتج العلية 
+ ```
+ yarn build:release
+```
 
-ملحوطة: يمكنك رفع ملف الwasm على حساب مخصص. تجد الخطوات فى هذا الرابظ  : https://www.youtube.com/watch?v=Yuid1QH_NWg&list=PLYH8jWLZAVt62bVY0aEnMquZn-jpTZPhQ&index=11
+استخدم الأمر التالي، ستجد بعد تنفيذ هذا الأمر ملف `friendbook.wasm` تم انشاءه فى هذا المسار`build/release` 
 
 
 
+
+4. لرفع الملف السابق على البلوك تشين قم بكتابة الأمر:
+```
+near dev-deploy ./build/release/friendbook.wasm
+```
+
+  
+5. هذا مثال لناتج تنفيذ الأمر السابق:
+
+
+
+<img width="1295" alt="Screen Shot 2022-03-03 at 5 29 42 PM" src="https://user-images.githubusercontent.com/58190902/156587143-ab38c8c7-a839-480d-853d-526d96a943b6.png">
+
+
+
+
+6.  يمكنك استخدام الدالة (function)`writeSomething` لكتابة رسالة وإضافة نص الرسالة والشخص المُرسل إليه 
+
+
+```
+near call dev-1646314780524-36067631587978 writeSomething '{"message":"Hello", "toWho":"three.testnet"}' --accountId four.testnet
+```
+
+
+7.  عند تمام العملية سوف تظهر لك النتائج التالية: 
+
+
+<img width="1103" alt="Screen Shot 2022-03-03 at 5 48 35 PM" src="https://user-images.githubusercontent.com/58190902/156601310-e09d2dc0-ea94-481b-b643-3be7d89b8d64.png">
+
+
+8.  يمكنك استخدام الدالة (function)`listWritings` لمشاهدة جميع الرسائل التي تمت إضافتها: 
+```
+near view dev-1646314780524-36067631587978 listWritings
+```
+
+9.  عند تمام العملية سوف تظهر لك النتائج التالية:
+<img width="1498" alt="Screen Shot 2022-03-03 at 6 57 11 PM" src="https://user-images.githubusercontent.com/58190902/156601916-fabcee0d-2635-4740-a663-c7ab221d9244.png">
+
+
+
+ملحوظة: يمكنك رفع ملف الwasm على حساب مخصص. تجد الخطوات فى هذا [الرابط]( https://www.youtube.com/watch?v=Yuid1QH_NWg&list=PLYH8jWLZAVt62bVY0aEnMquZn-jpTZPhQ&index=11)
+
+
+
+
+## مزيد من التفاصيل مع الشرح و التطبيق هنا:
+
+[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/PrPqBi_lSUc/0.jpg)](https://www.youtube.com/watch?v=PrPqBi_lSUc)


### PR DESCRIPTION
I updated the readme, I fixed a few mistakes:
For example in the old version all the slashes were the opposite like this:
`near dev-deploy .\build\release\friendbook.wasm`

In fact it should be like this: 
`near dev-deploy ./build/release/friendbook.wasm`

Maybe because of the Arabic markdown:

Now it looks like this: 
![Screen Shot 2022-03-03 at 6 59 29 PM](https://user-images.githubusercontent.com/58190902/156602751-b51b606d-ec35-4880-a33a-dd8c94bc6826.png)

